### PR TITLE
Move event constants from historyBuilder to constants  (#715)

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -29,6 +29,10 @@ const (
 	EmptyVersion int64 = -24
 	// EndEventID is the id of the end event, here we use the int64 max
 	EndEventID int64 = 1<<63 - 1
+	// BufferedEventID is the id of the buffered event
+	BufferedEventID int64 = -123
+	// TransientEventID is the id of the transient event
+	TransientEventID int64 = -124
 )
 
 const (

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -29,15 +29,6 @@ import (
 	"github.com/uber/cadence/common/persistence"
 )
 
-const (
-	emptyVersion int64 = -2234
-
-	firstEventID     int64 = 1
-	emptyEventID     int64 = -23
-	bufferedEventID  int64 = -123
-	transientEventID int64 = -124
-)
-
 type (
 	historyBuilder struct {
 		serializer persistence.HistorySerializer

--- a/service/history/historyBuilder_test.go
+++ b/service/history/historyBuilder_test.go
@@ -87,8 +87,8 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(int64(3), s.getNextEventID())
 	di0, decisionRunning0 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning0)
-	s.Equal(emptyEventID, di0.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di0.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionStartedEvent := s.addDecisionTaskStartedEvent(2, tl, identity)
 	s.validateDecisionTaskStartedEvent(decisionStartedEvent, 3, 2, identity)
@@ -98,7 +98,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.NotNil(di1)
 	decisionStartedID1 := di1.StartedID
 	s.Equal(int64(3), decisionStartedID1)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionContext := []byte("dynamic-historybuilder-success-context")
 	decisionCompletedEvent := s.addDecisionTaskCompletedEvent(2, 3, decisionContext, identity)
@@ -124,7 +124,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(int64(6), s.getNextEventID())
 	ai0, activity1Running0 := s.msBuilder.GetActivityInfo(5)
 	s.True(activity1Running0)
-	s.Equal(emptyEventID, ai0.StartedID)
+	s.Equal(common.EmptyEventID, ai0.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	activity2ID := "activity2"
@@ -139,11 +139,11 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(int64(7), s.getNextEventID())
 	ai2, activity2Running0 := s.msBuilder.GetActivityInfo(6)
 	s.True(activity2Running0)
-	s.Equal(emptyEventID, ai2.StartedID)
+	s.Equal(common.EmptyEventID, ai2.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	activityStartedEvent := s.addActivityTaskStartedEvent(5, activityTaskList, identity)
-	s.validateActivityTaskStartedEvent(activityStartedEvent, bufferedEventID, 5, identity)
+	s.validateActivityTaskStartedEvent(activityStartedEvent, common.BufferedEventID, 5, identity)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateActivityTaskStartedEvent(activityStartedEvent, 7, 5, identity)
 	s.Equal(int64(8), s.getNextEventID())
@@ -153,7 +153,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	activityCompletedEvent := s.addActivityTaskCompletedEvent(5, 7, activity1Result, identity)
-	s.validateActivityTaskCompletedEvent(activityCompletedEvent, bufferedEventID, 5, 7, activity1Result,
+	s.validateActivityTaskCompletedEvent(activityCompletedEvent, common.BufferedEventID, 5, 7, activity1Result,
 		identity)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateActivityTaskCompletedEvent(activityCompletedEvent, 8, 5, 7, activity1Result,
@@ -168,11 +168,11 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(int64(10), s.getNextEventID())
 	di3, decisionRunning3 := s.msBuilder.GetPendingDecision(9)
 	s.True(decisionRunning3)
-	s.Equal(emptyEventID, di3.StartedID)
+	s.Equal(common.EmptyEventID, di3.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	activity2StartedEvent := s.addActivityTaskStartedEvent(6, activityTaskList, identity)
-	s.validateActivityTaskStartedEvent(activity2StartedEvent, bufferedEventID, 6, identity)
+	s.validateActivityTaskStartedEvent(activity2StartedEvent, common.BufferedEventID, 6, identity)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateActivityTaskStartedEvent(activity2StartedEvent, 10, 6, identity)
 	s.Equal(int64(11), s.getNextEventID())
@@ -183,7 +183,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 
 	activity2FailedEvent := s.addActivityTaskFailedEvent(6, 10, activity2Reason, activity2Details,
 		identity)
-	s.validateActivityTaskFailedEvent(activity2FailedEvent, bufferedEventID, 6, 10, activity2Reason,
+	s.validateActivityTaskFailedEvent(activity2FailedEvent, common.BufferedEventID, 6, 10, activity2Reason,
 		activity2Details, identity)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateActivityTaskFailedEvent(activity2FailedEvent, 11, 6, 10, activity2Reason,
@@ -217,16 +217,16 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowStartFailures() {
 	s.Equal(int64(3), s.getNextEventID())
 	di0, decisionRunning0 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning0)
-	s.Equal(emptyEventID, di0.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di0.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	workflowStartedEvent2 := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity)
 	s.Nil(workflowStartedEvent2)
 	s.Equal(int64(3), s.getNextEventID(), s.printHistory())
 	di1, decisionRunning1 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning1)
-	s.Equal(emptyEventID, di1.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di1.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 }
 
 func (s *historyBuilderSuite) TestHistoryBuilderDecisionScheduledFailures() {
@@ -252,16 +252,16 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionScheduledFailures() {
 	s.Equal(int64(3), s.getNextEventID())
 	di0, decisionRunning0 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning0)
-	s.Equal(emptyEventID, di0.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di0.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	di2 := s.addDecisionTaskScheduledEvent()
 	s.Nil(di2)
 	s.Equal(int64(3), s.getNextEventID())
 	di1, decisionRunning1 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning1)
-	s.Equal(emptyEventID, di1.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di1.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 }
 
 func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedFailures() {
@@ -287,23 +287,23 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedFailures() {
 	s.Equal(int64(2), s.getNextEventID())
 	_, decisionRunning1 := s.msBuilder.GetPendingDecision(2)
 	s.False(decisionRunning1)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	di := s.addDecisionTaskScheduledEvent()
 	s.validateDecisionTaskScheduledEvent(di, 2, tl, taskTimeout)
 	s.Equal(int64(3), s.getNextEventID())
 	di0, decisionRunning0 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning0)
-	s.Equal(emptyEventID, di0.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di0.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionStartedEvent1 := s.addDecisionTaskStartedEvent(100, tl, identity)
 	s.Nil(decisionStartedEvent1)
 	s.Equal(int64(3), s.getNextEventID())
 	di2, decisionRunning2 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning2)
-	s.Equal(emptyEventID, di2.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di2.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionStartedEvent2 := s.addDecisionTaskStartedEvent(2, tl, identity)
 	s.validateDecisionTaskStartedEvent(decisionStartedEvent2, 3, 2, identity)
@@ -311,7 +311,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedFailures() {
 	di3, decisionRunning3 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning3)
 	s.Equal(int64(3), di3.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 }
 
 func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
@@ -339,8 +339,8 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	s.Equal(int64(3), s.getNextEventID())
 	di0, decisionRunning0 := s.msBuilder.GetPendingDecision(2)
 	s.True(decisionRunning0)
-	s.Equal(emptyEventID, di0.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, di0.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	// 3 decision started
 	decisionStartedEvent := s.addDecisionTaskStartedEvent(2, tl, identity)
@@ -351,7 +351,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	s.NotNil(di1)
 	decisionStartedID1 := di1.StartedID
 	s.Equal(int64(3), decisionStartedID1)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	// 4 decision completed
 	decisionContext := []byte("flush-buffered-events-context")
@@ -379,7 +379,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	s.Equal(int64(6), s.getNextEventID())
 	ai0, activity1Running0 := s.msBuilder.GetActivityInfo(5)
 	s.True(activity1Running0)
-	s.Equal(emptyEventID, ai0.StartedID)
+	s.Equal(common.EmptyEventID, ai0.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	// 6 activity 2 scheduled
@@ -393,12 +393,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	s.Equal(int64(7), s.getNextEventID())
 	ai2, activity2Running0 := s.msBuilder.GetActivityInfo(6)
 	s.True(activity2Running0)
-	s.Equal(emptyEventID, ai2.StartedID)
+	s.Equal(common.EmptyEventID, ai2.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	// 7 activity1 started
 	activityStartedEvent := s.addActivityTaskStartedEvent(5, activityTaskList, identity)
-	s.validateActivityTaskStartedEvent(activityStartedEvent, bufferedEventID, 5, identity)
+	s.validateActivityTaskStartedEvent(activityStartedEvent, common.BufferedEventID, 5, identity)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateActivityTaskStartedEvent(activityStartedEvent, 7, 5, identity)
 	s.Equal(int64(8), s.getNextEventID())
@@ -409,7 +409,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 
 	// 8 activity1 completed
 	activityCompletedEvent := s.addActivityTaskCompletedEvent(5, 7, activity1Result, identity)
-	s.validateActivityTaskCompletedEvent(activityCompletedEvent, bufferedEventID, 5, 7, activity1Result, identity)
+	s.validateActivityTaskCompletedEvent(activityCompletedEvent, common.BufferedEventID, 5, 7, activity1Result, identity)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateActivityTaskCompletedEvent(activityCompletedEvent, 8, 5, 7, activity1Result, identity)
 	s.Equal(int64(9), s.getNextEventID())
@@ -423,7 +423,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	s.Equal(int64(10), s.getNextEventID())
 	di3, decisionRunning3 := s.msBuilder.GetPendingDecision(9)
 	s.True(decisionRunning3)
-	s.Equal(emptyEventID, di3.StartedID)
+	s.Equal(common.EmptyEventID, di3.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	// 10 decision2 started
@@ -439,18 +439,18 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 
 	// 11 (buffered) activity2 started
 	activity2StartedEvent := s.addActivityTaskStartedEvent(6, activityTaskList, identity)
-	s.validateActivityTaskStartedEvent(activity2StartedEvent, bufferedEventID, 6, identity)
+	s.validateActivityTaskStartedEvent(activity2StartedEvent, common.BufferedEventID, 6, identity)
 	s.Equal(int64(11), s.getNextEventID())
 	ai4, activity2Running := s.msBuilder.GetActivityInfo(6)
 	s.True(activity2Running)
-	s.Equal(bufferedEventID, ai4.StartedID)
+	s.Equal(common.BufferedEventID, ai4.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	// 12 (buffered) activity2 failed
 	activity2Reason := "flush-buffered-events-activity2-failed"
 	activity2Details := []byte("flush-buffered-events-activity2-callstack")
-	activity2FailedEvent := s.addActivityTaskFailedEvent(6, bufferedEventID, activity2Reason, activity2Details, identity)
-	s.validateActivityTaskFailedEvent(activity2FailedEvent, bufferedEventID, 6, bufferedEventID, activity2Reason,
+	activity2FailedEvent := s.addActivityTaskFailedEvent(6, common.BufferedEventID, activity2Reason, activity2Details, identity)
+	s.validateActivityTaskFailedEvent(activity2FailedEvent, common.BufferedEventID, 6, common.BufferedEventID, activity2Reason,
 		activity2Details, identity)
 	s.Equal(int64(11), s.getNextEventID())
 	_, activity2Running2 := s.msBuilder.GetActivityInfo(6)
@@ -507,8 +507,8 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationRequested() 
 	s.True(decisionRunning)
 	s.NotNil(decisionInfo)
 	s.Equal(int64(2), decisionInfo.ScheduleID)
-	s.Equal(emptyEventID, decisionInfo.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, decisionInfo.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionStartedEvent := s.addDecisionTaskStartedEvent(2, tasklist, identity)
 	s.validateDecisionTaskStartedEvent(decisionStartedEvent, 3, 2, identity)
@@ -518,7 +518,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationRequested() 
 	s.NotNil(decisionInfo)
 	s.Equal(int64(2), decisionInfo.ScheduleID)
 	s.Equal(int64(3), decisionInfo.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionContext := []byte("some random decision context")
 	decisionCompletedEvent := s.addDecisionTaskCompletedEvent(2, 3, decisionContext, identity)
@@ -546,7 +546,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationRequested() 
 	cancellationRequestedEvent := s.addExternalWorkflowExecutionCancelRequested(
 		5, targetDomain, targetExecution.GetWorkflowId(), targetExecution.GetRunId(),
 	)
-	s.validateExternalWorkflowExecutionCancelRequested(cancellationRequestedEvent, bufferedEventID, 5, targetDomain, targetExecution)
+	s.validateExternalWorkflowExecutionCancelRequested(cancellationRequestedEvent, common.BufferedEventID, 5, targetDomain, targetExecution)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateExternalWorkflowExecutionCancelRequested(cancellationRequestedEvent, 6, 5, targetDomain, targetExecution)
 	s.Equal(int64(7), s.getNextEventID())
@@ -579,8 +579,8 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationFailed() {
 	s.True(decisionRunning)
 	s.NotNil(decisionInfo)
 	s.Equal(int64(2), decisionInfo.ScheduleID)
-	s.Equal(emptyEventID, decisionInfo.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, decisionInfo.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionStartedEvent := s.addDecisionTaskStartedEvent(2, tasklist, identity)
 	s.validateDecisionTaskStartedEvent(decisionStartedEvent, 3, 2, identity)
@@ -590,7 +590,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationFailed() {
 	s.NotNil(decisionInfo)
 	s.Equal(int64(2), decisionInfo.ScheduleID)
 	s.Equal(int64(3), decisionInfo.StartedID)
-	s.Equal(emptyEventID, s.getPreviousDecisionStartedEventID())
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	decisionContext := []byte("some random decision context")
 	decisionCompletedEvent := s.addDecisionTaskCompletedEvent(2, 3, decisionContext, identity)
@@ -620,7 +620,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationFailed() {
 		4, 5, targetDomain, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), cancellationFailedCause,
 	)
 	s.validateRequestCancelExternalWorkflowExecutionFailedEvent(
-		cancellationRequestedEvent, bufferedEventID, 4, 5, targetDomain, targetExecution, cancellationFailedCause,
+		cancellationRequestedEvent, common.BufferedEventID, 4, 5, targetDomain, targetExecution, cancellationFailedCause,
 	)
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateRequestCancelExternalWorkflowExecutionFailedEvent(
@@ -766,7 +766,7 @@ func (s *historyBuilderSuite) validateWorkflowExecutionStartedEvent(event *workf
 	taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32, identity string) {
 	s.NotNil(event)
 	s.Equal(workflow.EventTypeWorkflowExecutionStarted, *event.EventType)
-	s.Equal(firstEventID, *event.EventId)
+	s.Equal(common.FirstEventID, *event.EventId)
 	attributes := event.WorkflowExecutionStartedEventAttributes
 	s.NotNil(attributes)
 	s.Equal(workflowType, *attributes.WorkflowType.Name)

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -225,7 +225,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 	}
 
 	var parentExecution *workflow.WorkflowExecution
-	initiatedID := emptyEventID
+	initiatedID := common.EmptyEventID
 	parentDomainID := ""
 	parentInfo := startRequest.ParentExecutionInfo
 	if parentInfo != nil {
@@ -251,9 +251,9 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 	}
 
 	var transferTasks []persistence.Task
-	decisionVersion := emptyVersion
-	decisionScheduleID := emptyEventID
-	decisionStartID := emptyEventID
+	decisionVersion := common.EmptyVersion
+	decisionScheduleID := common.EmptyEventID
+	decisionStartID := common.EmptyEventID
 	decisionTimeout := int32(0)
 	if parentInfo == nil {
 		// DecisionTask is only created when it is not a Child Workflow Execution
@@ -311,7 +311,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 		}
 
 		replicationTask := &persistence.HistoryReplicationTask{
-			FirstEventID:        firstEventID,
+			FirstEventID:        common.FirstEventID,
 			NextEventID:         msBuilder.GetNextEventID(),
 			Version:             failoverVersion,
 			LastReplicationInfo: nil,
@@ -334,7 +334,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 			DecisionTimeoutValue:        *request.TaskStartToCloseTimeoutSeconds,
 			ExecutionContext:            nil,
 			NextEventID:                 msBuilder.GetNextEventID(),
-			LastProcessedEvent:          emptyEventID,
+			LastProcessedEvent:          common.EmptyEventID,
 			TransferTasks:               transferTasks,
 			ReplicationTasks:            replicationTasks,
 			DecisionVersion:             decisionVersion,
@@ -607,7 +607,7 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(
 			state := workflow.PendingActivityStateScheduled
 			if pi.CancelRequested {
 				state = workflow.PendingActivityStateCancelRequested
-			} else if pi.StartedID != emptyEventID {
+			} else if pi.StartedID != common.EmptyEventID {
 				state = workflow.PendingActivityStateStarted
 			}
 			ai.State = &state
@@ -669,12 +669,12 @@ Update_History_Loop:
 			// Looks like DecisionTask already completed as a result of another call.
 			// It is OK to drop the task at this point.
 			logging.LogDuplicateTaskEvent(context.logger, persistence.TransferTaskTypeDecisionTask, common.Int64Default(request.TaskId), requestID,
-				scheduleID, emptyEventID, isRunning)
+				scheduleID, common.EmptyEventID, isRunning)
 
 			return nil, &workflow.EntityNotExistsError{Message: "Decision task not found."}
 		}
 
-		if di.StartedID != emptyEventID {
+		if di.StartedID != common.EmptyEventID {
 			// If decision is started as part of the current request scope then return a positive response
 			if di.RequestID == requestID {
 				return e.createRecordDecisionTaskStartedResponse(domainID, msBuilder, di, request.PollRequest.GetIdentity()), nil
@@ -760,7 +760,7 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 				// Looks like ActivityTask already completed as a result of another call.
 				// It is OK to drop the task at this point.
 				logging.LogDuplicateTaskEvent(e.logger, persistence.TransferTaskTypeActivityTask,
-					common.Int64Default(request.TaskId), requestID, scheduleID, emptyEventID, isRunning)
+					common.Int64Default(request.TaskId), requestID, scheduleID, common.EmptyEventID, isRunning)
 
 				return nil, ErrActivityTaskNotFound
 			}
@@ -772,7 +772,7 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 			response.ScheduledEvent = scheduledEvent
 			response.ScheduledTimestampOfThisAttempt = common.Int64Ptr(ai.ScheduledTime.UnixNano())
 
-			if ai.StartedID != emptyEventID {
+			if ai.StartedID != common.EmptyEventID {
 				// If activity is started as part of the current request scope then return a positive response
 				if ai.RequestID == requestID {
 					response.StartedTimestamp = common.Int64Ptr(ai.StartedTime.UnixNano())
@@ -861,7 +861,7 @@ Update_History_Loop:
 		}
 
 		if !msBuilder.isWorkflowExecutionRunning() || !isRunning || di.Attempt != token.ScheduleAttempt ||
-			di.StartedID == emptyEventID {
+			di.StartedID == common.EmptyEventID {
 			return &workflow.EntityNotExistsError{Message: "Decision task not found."}
 		}
 
@@ -1042,7 +1042,7 @@ Update_History_Loop:
 					continue Process_Decision_Loop
 				}
 
-				if ai.StartedID == emptyEventID {
+				if ai.StartedID == common.EmptyEventID {
 					// We haven't started the activity yet, we can cancel the activity right away.
 					msBuilder.AddActivityTaskCanceledEvent(ai.ScheduleID, ai.StartedID, *actCancelReqEvent.EventId,
 						[]byte(activityCancelationMsgActivityNotStarted), common.StringDefault(request.Identity))
@@ -1343,7 +1343,7 @@ func (e *historyEngineImpl) RespondDecisionTaskFailed(req *h.RespondDecisionTask
 
 			scheduleID := token.ScheduleID
 			di, isRunning := msBuilder.GetPendingDecision(scheduleID)
-			if !isRunning || di.Attempt != token.ScheduleAttempt || di.StartedID == emptyEventID {
+			if !isRunning || di.Attempt != token.ScheduleAttempt || di.StartedID == common.EmptyEventID {
 				return nil, &workflow.EntityNotExistsError{Message: "Decision task not found."}
 			}
 
@@ -1396,7 +1396,7 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(req *h.RespondActivityT
 				return nil, ErrStaleState
 			}
 
-			if !isRunning || ai.StartedID == emptyEventID ||
+			if !isRunning || ai.StartedID == common.EmptyEventID ||
 				(token.ScheduleAttempt != 0 && int64(ai.Attempt) != token.ScheduleAttempt) {
 				return nil, ErrActivityTaskNotFound
 			}
@@ -1452,8 +1452,8 @@ func (e *historyEngineImpl) RespondActivityTaskFailed(req *h.RespondActivityTask
 				return nil, ErrStaleState
 			}
 
-			if !isRunning || ai.StartedID == emptyEventID ||
-				(token.ScheduleID != emptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
+			if !isRunning || ai.StartedID == common.EmptyEventID ||
+				(token.ScheduleID != common.EmptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
 				return nil, ErrActivityTaskNotFound
 			}
 
@@ -1516,8 +1516,8 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(req *h.RespondActivityTa
 				return nil, ErrStaleState
 			}
 
-			if !isRunning || ai.StartedID == emptyEventID ||
-				(token.ScheduleID != emptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
+			if !isRunning || ai.StartedID == common.EmptyEventID ||
+				(token.ScheduleID != common.EmptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
 				return nil, ErrActivityTaskNotFound
 			}
 
@@ -1580,8 +1580,8 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 				return nil, ErrStaleState
 			}
 
-			if !isRunning || ai.StartedID == emptyEventID ||
-				(token.ScheduleID != emptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
+			if !isRunning || ai.StartedID == common.EmptyEventID ||
+				(token.ScheduleID != common.EmptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
 				e.logger.Debugf("Activity HeartBeat: scheduleEventID: %v, ActivityInfo: %+v, Exist: %v", scheduleID, ai,
 					isRunning)
 				return nil, ErrActivityTaskNotFound
@@ -1873,14 +1873,14 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(signalWithStartRequ
 			RequestID:                   common.StringDefault(request.RequestId),
 			DomainID:                    domainID,
 			Execution:                   execution,
-			InitiatedID:                 emptyEventID,
+			InitiatedID:                 common.EmptyEventID,
 			TaskList:                    *request.TaskList.Name,
 			WorkflowTypeName:            *request.WorkflowType.Name,
 			WorkflowTimeout:             *request.ExecutionStartToCloseTimeoutSeconds,
 			DecisionTimeoutValue:        *request.TaskStartToCloseTimeoutSeconds,
 			ExecutionContext:            nil,
 			NextEventID:                 msBuilder.GetNextEventID(),
-			LastProcessedEvent:          emptyEventID,
+			LastProcessedEvent:          common.EmptyEventID,
 			TransferTasks:               transferTasks,
 			DecisionVersion:             decisionVersion,
 			DecisionScheduleID:          decisionScheduleID,
@@ -2024,7 +2024,7 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(completionRequest *h.R
 
 			// Check mutable state to make sure child execution is in pending child executions
 			ci, isRunning := msBuilder.GetChildExecutionInfo(initiatedID)
-			if !isRunning || ci.StartedID == emptyEventID {
+			if !isRunning || ci.StartedID == common.EmptyEventID {
 				return nil, &workflow.EntityNotExistsError{Message: "Pending child execution not found."}
 			}
 
@@ -2184,7 +2184,7 @@ func (e *historyEngineImpl) createRecordDecisionTaskStartedResponse(domainID str
 	di *decisionInfo, identity string) *h.RecordDecisionTaskStartedResponse {
 	response := &h.RecordDecisionTaskStartedResponse{}
 	response.WorkflowType = msBuilder.getWorkflowType()
-	if msBuilder.previousDecisionStartedEvent() != emptyEventID {
+	if msBuilder.previousDecisionStartedEvent() != common.EmptyEventID {
 		response.PreviousStartedEventId = common.Int64Ptr(msBuilder.previousDecisionStartedEvent())
 	}
 

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -1931,7 +1931,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedConflictOnUpdate() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(10), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskCompletedMaxAttemptsExceeded() {
@@ -2062,7 +2062,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedSuccess() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
@@ -2135,7 +2135,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskFailedInvalidToken() {
@@ -2616,7 +2616,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedConflictOnUpdate() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(10), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskFailedMaxAttemptsExceeded() {
@@ -2747,7 +2747,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedSuccess() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskFailedByIDSuccess() {
@@ -2822,7 +2822,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIDSuccess() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_NoTimer() {
@@ -3132,7 +3132,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(9), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskCanceledByID_Started() {
@@ -3204,7 +3204,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledByID_Started() {
 	s.True(ok)
 	s.Equal(int32(200), di.DecisionTimeout)
 	s.Equal(int64(9), di.ScheduleID)
-	s.Equal(emptyEventID, di.StartedID)
+	s.Equal(common.EmptyEventID, di.StartedID)
 }
 
 func (s *engineSuite) TestRespondActivityTaskCanceledIfNoRunID() {

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -207,7 +207,7 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 	case shared.EventTypeWorkflowExecutionStarted:
 		// TODO: Support for child execution
 		var parentExecution *shared.WorkflowExecution
-		initiatedID := emptyEventID
+		initiatedID := common.EmptyEventID
 		parentDomainID := ""
 
 		// Serialize the history
@@ -249,9 +249,9 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 		}
 
 		// Set decision attributes after replication of history events
-		decisionVersionID := emptyVersion
-		decisionScheduleID := emptyEventID
-		decisionStartID := emptyEventID
+		decisionVersionID := common.EmptyVersion
+		decisionScheduleID := common.EmptyEventID
+		decisionStartID := common.EmptyEventID
 		decisionTimeout := int32(0)
 		if di != nil {
 			decisionVersionID = di.Version
@@ -275,7 +275,7 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 				DecisionTimeoutValue:        msBuilder.executionInfo.DecisionTimeoutValue,
 				ExecutionContext:            nil,
 				NextEventID:                 msBuilder.GetNextEventID(),
-				LastProcessedEvent:          emptyEventID,
+				LastProcessedEvent:          common.EmptyEventID,
 				TransferTasks:               sBuilder.transferTasks,
 				DecisionVersion:             decisionVersionID,
 				DecisionScheduleID:          decisionScheduleID,

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -133,7 +133,7 @@ func (p *replicatorQueueProcessorImpl) processHistoryReplicationTask(task *persi
 		lastEvent := events[len(events)-1]
 		if lastEvent.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
 			newRunID := lastEvent.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunId()
-			newRunHistory, err = p.getHistory(task.DomainID, task.WorkflowID, newRunID, firstEventID, int64(3))
+			newRunHistory, err = p.getHistory(task.DomainID, task.WorkflowID, newRunID, common.FirstEventID, int64(3))
 			if err != nil {
 				return err
 			}

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -78,7 +79,7 @@ func prepareNextRetryWithNowTime(a *persistence.ActivityInfo, errReason string, 
 	// a retry is needed, update activity info for next retry
 	a.Attempt++
 	a.ScheduledTime = nextScheduleTime // update to next schedule time
-	a.StartedID = emptyEventID
+	a.StartedID = common.EmptyEventID
 	a.RequestID = ""
 	a.StartedTime = time.Time{}
 	a.LastHeartBeatUpdatedTime = time.Time{}

--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -274,7 +274,7 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder *mutableStateBuilder) {
 	tb.pendingActivityTimers = msBuilder.pendingActivityInfoIDs
 	tb.activityTimers = make(timers, 0, len(msBuilder.pendingActivityInfoIDs))
 	for _, v := range msBuilder.pendingActivityInfoIDs {
-		if v.ScheduleID != emptyEventID {
+		if v.ScheduleID != common.EmptyEventID {
 			scheduleToCloseExpiry := v.ExpirationTime
 			if scheduleToCloseExpiry.IsZero() {
 				// v.ExpirationTime could be zero for old activity_infos before this code change (for retry)
@@ -290,7 +290,7 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder *mutableStateBuilder) {
 				TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedScheduleToClose) != 0}
 			tb.activityTimers = append(tb.activityTimers, td)
 
-			if v.StartedID != emptyEventID {
+			if v.StartedID != common.EmptyEventID {
 				startToCloseExpiry := v.StartedTime.Add(time.Duration(v.StartToCloseTimeout) * time.Second)
 				td := &timerDetails{
 					TimerSequenceID: TimerSequenceID{VisibilityTimestamp: startToCloseExpiry},
@@ -416,7 +416,7 @@ func (tb *timerBuilder) createNewTask(td *timerDetails) persistence.Task {
 			VisibilityTimestamp: td.TimerSequenceID.VisibilityTimestamp,
 			EventID:             tt.StartedID,
 		}
-	} else if td.ActivityID != 0 && td.ActivityID != emptyEventID {
+	} else if td.ActivityID != 0 && td.ActivityID != common.EmptyEventID {
 		return &persistence.ActivityTimeoutTask{
 			VisibilityTimestamp: td.TimerSequenceID.VisibilityTimestamp,
 			EventID:             td.EventID,

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -180,7 +180,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderDuplicateTimerID() {
 func (s *timerBuilderProcessorSuite) TestTimerBuilder_GetActivityTimer() {
 	// ScheduleToStart being more than HB.
 	builder := newMutableStateBuilder(s.config, s.logger)
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("test-id"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(2),

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -378,7 +378,7 @@ Update_History_Loop:
 				case workflow.TimeoutTypeStartToClose:
 					{
 						t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.StartToCloseTimeoutCounter)
-						if ai.StartedID != emptyEventID {
+						if ai.StartedID != common.EmptyEventID {
 							if msBuilder.AddActivityTaskTimedOutEvent(ai.ScheduleID, ai.StartedID, timeoutType, nil) == nil {
 								return errFailedToAddTimeoutEvent
 							}
@@ -400,7 +400,7 @@ Update_History_Loop:
 				case workflow.TimeoutTypeScheduleToStart:
 					{
 						t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.ScheduleToStartTimeoutCounter)
-						if ai.StartedID == emptyEventID {
+						if ai.StartedID == common.EmptyEventID {
 							if msBuilder.AddActivityTaskTimedOutEvent(ai.ScheduleID, ai.StartedID, timeoutType, nil) == nil {
 								return errFailedToAddTimeoutEvent
 							}
@@ -420,7 +420,7 @@ Update_History_Loop:
 				// for activity in the timertask.  But we still need to check if the ID matches Started eventID or
 				// bufferedEventID due to the heartbeat timers created before the bugfix.
 				if !td.TaskCreated || (isHeartBeatTask && (scheduleID == td.EventID || scheduleID == ai.StartedID ||
-					scheduleID == bufferedEventID) && int64(td.Attempt) == timerTask.ScheduleAttempt) {
+					scheduleID == common.BufferedEventID) && int64(td.Attempt) == timerTask.ScheduleAttempt) {
 					nextTask := tBuilder.createNewTask(td)
 					timerTasks = append(timerTasks, nextTask)
 					at := nextTask.(*persistence.ActivityTimeoutTask)
@@ -514,7 +514,7 @@ Update_History_Loop:
 			t.metricsClient.IncCounter(metrics.TimerTaskDecisionTimeoutScope, metrics.ScheduleToStartTimeoutCounter)
 			// decision schedule to start timeout only apply to sticky decision
 			// check if scheduled decision still pending and not started yet
-			if di.Attempt == task.ScheduleAttempt && di.StartedID == emptyEventID && msBuilder.isStickyTaskListEnabled() {
+			if di.Attempt == task.ScheduleAttempt && di.StartedID == common.EmptyEventID && msBuilder.isStickyTaskListEnabled() {
 				timeoutEvent := msBuilder.AddDecisionTaskScheduleToStartTimeoutEvent(scheduleID)
 				if timeoutEvent == nil {
 					// Unable to add DecisionTaskTimedout event to history

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -192,7 +192,7 @@ func (s *timerQueueProcessorSuite) addUserTimer(domainID string, we workflow.Wor
 	condition := state.ExecutionInfo.NextEventID
 
 	// create a user timer
-	_, ti := builder.AddTimerStartedEvent(emptyEventID,
+	_, ti := builder.AddTimerStartedEvent(common.EmptyEventID,
 		&workflow.StartTimerDecisionAttributes{TimerId: common.StringPtr(timerID), StartToFireTimeoutSeconds: common.Int64Ptr(1)})
 	tb.AddUserTimer(ti, builder)
 	t := tb.GetUserTimerTaskIfNeeded(builder)
@@ -211,7 +211,7 @@ func (s *timerQueueProcessorSuite) addHeartBeatTimer(domainID string,
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:              common.StringPtr("testID"),
 			HeartbeatTimeoutSeconds: common.Int32Ptr(1),
@@ -410,7 +410,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithOutS
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	activityScheduledEvent, _ := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	activityScheduledEvent, _ := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -452,7 +452,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithStar
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -496,7 +496,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_MoreThan
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	activityScheduledEvent, _ := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	activityScheduledEvent, _ := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(2),
@@ -539,7 +539,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_WithStart()
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -581,7 +581,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_CompletedAc
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -628,7 +628,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_JustSche
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, _ := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, _ := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -670,7 +670,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Started(
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -714,7 +714,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Complete
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase, ai := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase, ai := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -787,7 +787,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTask_SameExpiry() {
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
-	ase1, ai1 := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase1, ai1 := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID-1"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -795,7 +795,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTask_SameExpiry() {
 			TaskList:                      &workflow.TaskList{Name: common.StringPtr("task-list")},
 		})
 	s.NotNil(ase1)
-	ase2, ai2 := builder.AddActivityTaskScheduledEvent(emptyEventID,
+	ase2, ai2 := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("testID-2"),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
@@ -877,9 +877,9 @@ func (s *timerQueueProcessorSuite) TestTimerUserTimers_SameExpiry() {
 	timerTasks := []persistence.Task{}
 
 	// create two user timers.
-	_, ti := builder.AddTimerStartedEvent(emptyEventID,
+	_, ti := builder.AddTimerStartedEvent(common.EmptyEventID,
 		&workflow.StartTimerDecisionAttributes{TimerId: common.StringPtr("tid1"), StartToFireTimeoutSeconds: common.Int64Ptr(1)})
-	_, ti2 := builder.AddTimerStartedEvent(emptyEventID,
+	_, ti2 := builder.AddTimerStartedEvent(common.EmptyEventID,
 		&workflow.StartTimerDecisionAttributes{TimerId: common.StringPtr("tid2"), StartToFireTimeoutSeconds: common.Int64Ptr(1)})
 
 	tBuilder.AddUserTimer(ti, builder)

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -404,7 +404,7 @@ func (t *transferQueueActiveProcessorImpl) processDecisionTask(task *persistence
 		return err
 	}
 
-	if task.ScheduleID == firstEventID+1 {
+	if task.ScheduleID == common.FirstEventID+1 {
 		err = t.recordWorkflowExecutionStarted(execution, task, wfTypeName, startTimestamp, workflowTimeout)
 	}
 
@@ -849,7 +849,7 @@ func (t *transferQueueActiveProcessorImpl) processStartChildExecution(task *pers
 
 	initiatedEvent, ok := msBuilder.GetChildExecutionInitiatedEvent(initiatedEventID)
 	attributes := initiatedEvent.StartChildWorkflowExecutionInitiatedEventAttributes
-	if ok && ci.StartedID == emptyEventID {
+	if ok && ci.StartedID == common.EmptyEventID {
 		// Found pending child execution and it is not marked as started
 		// Let's try and start the child execution
 		startRequest := &h.StartWorkflowExecutionRequest{
@@ -944,7 +944,7 @@ func (t *transferQueueActiveProcessorImpl) recordChildExecutionStarted(task *per
 			domain := initiatedAttributes.Domain
 			initiatedEventID := task.ScheduleID
 			ci, isRunning := msBuilder.GetChildExecutionInfo(initiatedEventID)
-			if !isRunning || ci.StartedID != emptyEventID {
+			if !isRunning || ci.StartedID != common.EmptyEventID {
 				return &workflow.EntityNotExistsError{Message: "Pending child execution not found."}
 			}
 
@@ -970,7 +970,7 @@ func (t *transferQueueActiveProcessorImpl) recordStartChildExecutionFailed(task 
 
 			initiatedEventID := task.ScheduleID
 			ci, isRunning := msBuilder.GetChildExecutionInfo(initiatedEventID)
-			if !isRunning || ci.StartedID != emptyEventID {
+			if !isRunning || ci.StartedID != common.EmptyEventID {
 				return &workflow.EntityNotExistsError{Message: "Pending child execution not found."}
 			}
 
@@ -1070,7 +1070,7 @@ func (t *transferQueueActiveProcessorImpl) requestCancelFailed(task *persistence
 			}
 
 			msBuilder.AddRequestCancelExternalWorkflowExecutionFailedEvent(
-				emptyEventID,
+				common.EmptyEventID,
 				initiatedEventID,
 				request.GetDomainUUID(),
 				request.CancelRequest.WorkflowExecution.GetWorkflowId(),
@@ -1098,7 +1098,7 @@ func (t *transferQueueActiveProcessorImpl) requestSignalFailed(task *persistence
 			}
 
 			msBuilder.AddSignalExternalWorkflowExecutionFailedEvent(
-				emptyEventID,
+				common.EmptyEventID,
 				initiatedEventID,
 				request.GetDomainUUID(),
 				request.SignalRequest.WorkflowExecution.GetWorkflowId(),

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -203,7 +203,7 @@ func (t *transferQueueStandbyProcessorImpl) processActivityTask(transferTask *pe
 			return nil
 		}
 
-		if activityInfo.StartedID == emptyEventID {
+		if activityInfo.StartedID == common.EmptyEventID {
 			return ErrTaskRetry
 		}
 		return nil
@@ -220,7 +220,7 @@ func (t *transferQueueStandbyProcessorImpl) processDecisionTask(transferTask *pe
 		decisionInfo, isPending := msBuilder.GetPendingDecision(transferTask.ScheduleID)
 
 		if !isPending {
-			if transferTask.ScheduleID == firstEventID+1 {
+			if transferTask.ScheduleID == common.FirstEventID+1 {
 				return t.recordWorkflowStarted(msBuilder)
 			}
 			return nil
@@ -232,11 +232,11 @@ func (t *transferQueueStandbyProcessorImpl) processDecisionTask(transferTask *pe
 			return nil
 		}
 
-		if decisionInfo.StartedID == emptyEventID {
+		if decisionInfo.StartedID == common.EmptyEventID {
 			return ErrTaskRetry
 		}
 
-		if transferTask.ScheduleID == firstEventID+1 {
+		if transferTask.ScheduleID == common.FirstEventID+1 {
 			return t.recordWorkflowStarted(msBuilder)
 		}
 
@@ -344,7 +344,7 @@ func (t *transferQueueStandbyProcessorImpl) processStartChildExecution(transferT
 			return nil
 		}
 
-		if childWorkflowInfo.StartedID == emptyEventID {
+		if childWorkflowInfo.StartedID == common.EmptyEventID {
 			return ErrTaskRetry
 		}
 		return nil


### PR DESCRIPTION
* moves emptyVersion from historyBuilder to constants

* moves transientEventID from historyBuilder to constants

* moves bufferedEventID from historyBuilder to constants

* moves emptyEventID from historyBuilder to constants

* moves firstEventID from historyBuilder to constants

* fixes formatting error in service/history/retry.go